### PR TITLE
Fix path to font

### DIFF
--- a/styles/fonts.less
+++ b/styles/fonts.less
@@ -1,7 +1,6 @@
-
 @font-face {
   font-family: 'Montserrat';
-  src: url('fonts/montserrat-black-webfont.woff2') format('woff2');
+  src: url('nylas://Bemind-N1-Theme/styles/fonts/montserrat-black-webfont.woff2') format('woff2');
   font-weight: normal;
   font-style: normal;
 }
@@ -11,7 +10,7 @@
 
 @font-face {
   font-family: 'Montserrat';
-  src: url('fonts/montserrat-bold-webfont.woff2') format('woff2');
+  src: url('nylas://Bemind-N1-Theme/styles/fonts/montserrat-bold-webfont.woff2') format('woff2');
   font-weight: 700;
   font-style: normal;
 }
@@ -21,7 +20,7 @@
 
 @font-face {
   font-family: 'Montserrat';
-  src: url('fonts/montserrat-hairline-webfont.woff2') format('woff2');
+  src: url('nylas://Bemind-N1-Theme/styles/fonts/montserrat-hairline-webfont.woff2') format('woff2');
   font-weight: 100;
   font-style: normal;
 }
@@ -31,7 +30,7 @@
 
 @font-face {
   font-family: 'Montserrat';
-  src: url('fonts/montserrat-light-webfont.woff2') format('woff2');
+  src: url('nylas://Bemind-N1-Theme/styles/fonts/montserrat-light-webfont.woff2') format('woff2');
   font-weight: 300;
   font-style: normal;
 }
@@ -41,7 +40,7 @@
 
 @font-face {
   font-family: 'Montserrat';
-  src: url('fonts/montserrat-regular-webfont.woff2') format('woff2');
+  src: url('nylas://Bemind-N1-Theme/styles/fonts/montserrat-regular-webfont.woff2') format('woff2');
   font-weight: 400;
   font-style: normal;
 }


### PR DESCRIPTION
Love this theme! Montserrat wasn't rendering because the path was relative to the N1 `static/` directory, not to the package directory.
